### PR TITLE
removed collectd-packages, not needed for pdm

### DIFF
--- a/packages/backbone.txt
+++ b/packages/backbone.txt
@@ -44,8 +44,6 @@ luci-i18n-base-de
 luci-i18n-base-en
 luci-i18n-olsr-de
 luci-i18n-olsr-en
-luci-i18n-statistics-de
-luci-i18n-statistics-en
 
 # OLSR
 olsrd
@@ -63,13 +61,3 @@ alfred
 batctl
 
 # Statistics
-luci-app-statistics
-collectd
-collectd-mod-interface
-collectd-mod-iwinfo
-collectd-mod-network
-collectd-mod-olsrd
-collectd-mod-rrdtool
-collectd-mod-ping
-collectd-mod-uptime
-collectd-mod-memory

--- a/packages/default.txt
+++ b/packages/default.txt
@@ -51,8 +51,6 @@ luci-i18n-firewall-de
 luci-i18n-firewall-en
 luci-i18n-olsr-de
 luci-i18n-olsr-en
-luci-i18n-statistics-de
-luci-i18n-statistics-en
 
 # OLSR
 olsrd
@@ -73,13 +71,3 @@ batctl
 freifunk-berlin-uplink-notunnel-files
 
 # Statistics
-luci-app-statistics
-collectd
-collectd-mod-interface
-collectd-mod-iwinfo
-collectd-mod-network
-collectd-mod-olsrd
-collectd-mod-rrdtool
-collectd-mod-ping
-collectd-mod-uptime
-collectd-mod-memory

--- a/packages/tunnel-berlin-openvpn.txt
+++ b/packages/tunnel-berlin-openvpn.txt
@@ -53,8 +53,6 @@ luci-i18n-olsr-de
 luci-i18n-olsr-en
 luci-i18n-openvpn-de
 luci-i18n-openvpn-en
-luci-i18n-statistics-de
-luci-i18n-statistics-en
 
 # OLSR
 olsrd
@@ -78,13 +76,3 @@ freifunk-berlin-uplink-tunnelberlin-files
 luci-app-vpnbypass
 
 # Statistics
-luci-app-statistics
-collectd
-collectd-mod-interface
-collectd-mod-iwinfo
-collectd-mod-network
-collectd-mod-olsrd
-collectd-mod-rrdtool
-collectd-mod-ping
-collectd-mod-uptime
-collectd-mod-memory

--- a/packages/tunnel-berlin-tunneldigger.txt
+++ b/packages/tunnel-berlin-tunneldigger.txt
@@ -51,8 +51,6 @@ luci-i18n-firewall-de
 luci-i18n-firewall-en
 luci-i18n-olsr-de
 luci-i18n-olsr-en
-luci-i18n-statistics-de
-luci-i18n-statistics-en
 
 # OLSR
 olsrd
@@ -73,13 +71,3 @@ batctl
 freifunk-berlin-uplink-tunnelberlin-tunneldigger-files
 
 # Statistics
-luci-app-statistics
-collectd
-collectd-mod-interface
-collectd-mod-iwinfo
-collectd-mod-network
-collectd-mod-olsrd
-collectd-mod-rrdtool
-collectd-mod-ping
-collectd-mod-uptime
-collectd-mod-memory


### PR DESCRIPTION
Hab da mal die collectd packages rausgenommen, die wir für die potsdam builds nicht brauchen